### PR TITLE
Fix code scanning alert no. 4: Incorrect conversion between integer types

### DIFF
--- a/Chapter10/linksrus/service/frontend/frontend.go
+++ b/Chapter10/linksrus/service/frontend/frontend.go
@@ -282,7 +282,13 @@ func (svc *Service) runQuery(searchTerms string, offset uint64) ([]matchedDoc, *
 			pagination.PrevLink += fmt.Sprintf("&offset=%d", prevOffset)
 		}
 	}
-	if nextPageOffset := int(offset) + len(matchedDocs); nextPageOffset < pagination.Total {
+	var nextPageOffset int
+	if offset > uint64(^uint(0)>>1) {
+		nextPageOffset = int(^uint(0) >> 1) // max int value
+	} else {
+		nextPageOffset = int(offset) + len(matchedDocs)
+	}
+	if nextPageOffset < pagination.Total {
 		pagination.NextLink = fmt.Sprintf("%s?q=%s&offset=%d", searchEndpoint, searchTerms, nextPageOffset)
 	}
 


### PR DESCRIPTION
Fixes [https://github.com/ibiscum/Hands-On-Software-Engineering-with-Golang/security/code-scanning/4](https://github.com/ibiscum/Hands-On-Software-Engineering-with-Golang/security/code-scanning/4)

To fix the problem, we need to ensure that the conversion from `uint64` to `int` is safe by adding bounds checks. Specifically, we should check that the `uint64` value is within the range of the `int` type before performing the conversion. If the value is out of bounds, we should handle it appropriately, such as by returning an error or using a default value.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
