### PR TITLE
Fix code scanning alert no. 1: Incorrect conversion between integer types

### DIFF
--- a/Chapter06/textindexer/store/memory/bleve.go
+++ b/Chapter06/textindexer/store/memory/bleve.go
@@ -110,6 +110,9 @@ func (i *InMemoryBleveIndexer) Search(q index.Query) (index.Iterator, error) {
 	searchReq := bleve.NewSearchRequest(bq)
 	searchReq.SortBy([]string{"-PageRank", "-_score"})
 	searchReq.Size = batchSize
+	if q.Offset > uint64(^uint(0)) {
+		return nil, xerrors.Errorf("search: offset value out of bounds")
+	}
 	searchReq.From = int(q.Offset)
 	rs, err := i.idx.Search(searchReq)
 	if err != nil {


### PR DESCRIPTION
Fixes [https://github.com/ibiscum/Hands-On-Software-Engineering-with-Golang/security/code-scanning/1](https://github.com/ibiscum/Hands-On-Software-Engineering-with-Golang/security/code-scanning/1)

To fix the problem, we need to ensure that the `offset` value is within the bounds of the `int` type before performing the conversion. This can be achieved by adding a bounds check to ensure that the `offset` value does not exceed the maximum value of the `int` type. If the value is out of bounds, we can handle it appropriately, such as by returning an error or using a default value.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
