### PR TITLE
Fix code scanning alert no. 5: Incorrect conversion between integer types

### DIFF
--- a/Chapter10/linksrus/service/frontend/frontend.go
+++ b/Chapter10/linksrus/service/frontend/frontend.go
@@ -283,8 +283,8 @@ func (svc *Service) runQuery(searchTerms string, offset uint64) ([]matchedDoc, *
 		}
 	}
 	var nextPageOffset int
-	if offset > uint64(^uint(0)>>1) {
-		nextPageOffset = int(^uint(0) >> 1) // max int value
+	if offset > uint64(^int(0)) {
+		nextPageOffset = int(^int(0)) // max int value
 	} else {
 		nextPageOffset = int(offset) + len(matchedDocs)
 	}


### PR DESCRIPTION
Fixes [https://github.com/ibiscum/Hands-On-Software-Engineering-with-Golang/security/code-scanning/5](https://github.com/ibiscum/Hands-On-Software-Engineering-with-Golang/security/code-scanning/5)

To fix the problem, we need to ensure that the conversion from `uint64` to `int` is safe and does not result in unexpected values. This can be achieved by adding an upper bound check before performing the conversion. Specifically, we should check if the `uint64` value is within the range of an `int` type before converting it. If the value exceeds the maximum `int` value, we should handle it appropriately, such as by capping it at the maximum `int` value.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
