### PR TITLE
Fix code scanning alert no. 1: Incorrect conversion between integer types

### DIFF
--- a/Chapter06/textindexer/store/memory/bleve.go
+++ b/Chapter06/textindexer/store/memory/bleve.go
@@ -9,6 +9,7 @@ import (
 	"github.com/google/uuid"
 	"github.com/ibiscum/Hands-On-Software-Engineering-with-Golang/Chapter06/textindexer/index"
 	"golang.org/x/xerrors"
+	"math"
 )
 
 // The size of each page of results that is cached locally by the iterator.
@@ -110,7 +111,7 @@ func (i *InMemoryBleveIndexer) Search(q index.Query) (index.Iterator, error) {
 	searchReq := bleve.NewSearchRequest(bq)
 	searchReq.SortBy([]string{"-PageRank", "-_score"})
 	searchReq.Size = batchSize
-	if q.Offset > uint64(^uint(0)) {
+	if q.Offset > uint64(math.MaxInt) {
 		return nil, xerrors.Errorf("search: offset value out of bounds")
 	}
 	searchReq.From = int(q.Offset)


### PR DESCRIPTION
Fixes [https://github.com/ibiscum/Hands-On-Software-Engineering-with-Golang/security/code-scanning/1](https://github.com/ibiscum/Hands-On-Software-Engineering-with-Golang/security/code-scanning/1)

To fix the problem, we need to ensure that the `uint64` value is within the bounds of the `int` type before performing the conversion. This can be done by explicitly checking if the `uint64` value is less than or equal to the maximum value of the `int` type. If the value is out of bounds, we should handle the error appropriately.

The best way to fix this issue is to use the `math.MaxInt` constant to perform the bounds check. This will make the code more readable and robust.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
