### PR TITLE
Fix code scanning alert no. 5: Incorrect conversion between integer types

### DIFF
--- a/Chapter10/linksrus/service/frontend/frontend.go
+++ b/Chapter10/linksrus/service/frontend/frontend.go
@@ -285,6 +285,8 @@ func (svc *Service) runQuery(searchTerms string, offset uint64) ([]matchedDoc, *
 	var nextPageOffset int
 	if offset > uint64(^int(0)) {
 		nextPageOffset = int(^int(0)) // max int value
+	} else if offset+uint64(len(matchedDocs)) > uint64(^int(0)) {
+		nextPageOffset = int(^int(0)) // max int value
 	} else {
 		nextPageOffset = int(offset) + len(matchedDocs)
 	}


### PR DESCRIPTION
Fixes [https://github.com/ibiscum/Hands-On-Software-Engineering-with-Golang/security/code-scanning/5](https://github.com/ibiscum/Hands-On-Software-Engineering-with-Golang/security/code-scanning/5)

To fix the problem, we need to ensure that the `uint64` value is within the bounds of the `int` type before performing the conversion. This can be done by adding an upper bound check to ensure that the `offset` value does not exceed the maximum value that an `int` can hold. If the value is within bounds, we can safely convert it; otherwise, we should handle the overflow case appropriately.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
